### PR TITLE
Disable the 'std' feature of the num-traits dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Tools for convenient comparison of matrices"
 readme = "README.md"
 
 [dependencies]
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 matrixcompare-core = { path = "matrixcompare-core", version="0.1"}
 
 [dev-dependencies]


### PR DESCRIPTION
`matrixcompare` don't seem to actually need the default features (which includes `std`) of num-traits so is should they should be disabled to avoid breaking no-std builds of other crates depending on num-traits. This fixes the no-std build in https://github.com/rustsim/nalgebra/pull/631.