### PR TITLE
Fix "non_fmt_panic"

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -259,7 +259,7 @@ Please see the documentation for ways to compare matrices approximately.\n",
 #[macro_export]
 macro_rules! assert_matrix_eq {
     ($($args:tt)*) => {
-        $crate::base_matrix_eq!(|msg| panic!(msg), $($args)*);
+        $crate::base_matrix_eq!(|msg| panic!("{}", msg), $($args)*);
     };
 }
 
@@ -373,6 +373,6 @@ Please see the documentation for ways to compare scalars approximately.\n",
 #[macro_export]
 macro_rules! assert_scalar_eq {
     ($($args:tt)*) => {
-        $crate::base_scalar_eq!(|msg| panic!(msg), $($args)*);
+        $crate::base_scalar_eq!(|msg| panic!("{}", msg), $($args)*);
     };
 }


### PR DESCRIPTION
Since Rust 1.51(?), each expansion of the `assert_matrix_eq` macro will yield a warning that non-formatted arguments in `panic!` will be a hard error in Rust 2021. This quick-fix removes the issue, satisfies aggressive linters, and makes this crate future-proof. 