### PR TITLE
Update proptest to 1.0 and update matrixcompare to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Prominent changes for individual releases will be listed here.
 
+## 0.3.0 - (2020-04-30)
+
+### Changed
+
+- **Breaking**: Updated `proptest` to version 1.0. This is an optional dependency, so if you were not using it (through the `proptest-support` feature, there are no breaking changes.
+
 ## 0.2.1 - (2020-04-30)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ proptest-support = [ "proptest"]
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
 matrixcompare-core = { path = "matrixcompare-core", version="0.1"}
-proptest = { version = "0.10", optional = true }
+proptest = { version = "1.0", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrixcompare"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Andreas Longva"]
 edition = "2018"
 license = "MIT"

--- a/matrixcompare-minimal/Cargo.toml
+++ b/matrixcompare-minimal/Cargo.toml
@@ -5,4 +5,4 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-matrixcompare = { version = "=0.2.1", path = ".." }
+matrixcompare = { version = "=0.3.0", path = ".." }


### PR DESCRIPTION
This is a breaking change as `proptest` is a public dependency if the `proptest-support` is enabled