### PR TITLE
Update proptest dev-dependencies to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ proptest = { version = "1.0", optional = true }
 [dev-dependencies]
 quickcheck = "0.9"
 matrixcompare-mock = { path = "matrixcompare-mock", version="0.1" }
-proptest = "0.10"
+proptest = "1.0"
 pretty_assertions = "0.6.1"
 
 [package.metadata.docs.rs]

--- a/matrixcompare-mock/Cargo.toml
+++ b/matrixcompare-mock/Cargo.toml
@@ -10,5 +10,5 @@ description = "Internal mock data structures for testing of matrixcompare"
 [dependencies]
 num = "0.3"
 matrixcompare-core = { path = "../matrixcompare-core", version="0.1" }
-proptest = "0.10"
+proptest = "1.0"
 


### PR DESCRIPTION
The regular dependency on `proptest` is already at 1.0; this was the [major change in 0.3.0](https://github.com/Andlon/matrixcompare/blob/v0.3.0/CHANGELOG.md#030---2020-04-30). This PR updates the dev-dependencies on `proptest` to match. I confirmed that `cargo test --workspace` still passes.